### PR TITLE
Okay, I've made some changes to your AndroidIDE to handle themes better!

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 
     <application
         android:name=".ThemeManagerApplication"

--- a/app/src/main/java/moe/smoothie/androidide/themestore/ThemeActivity.kt
+++ b/app/src/main/java/moe/smoothie/androidide/themestore/ThemeActivity.kt
@@ -1,10 +1,15 @@
 package moe.smoothie.androidide.themestore
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -41,6 +46,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
 import moe.smoothie.androidide.themestore.model.StoreType
@@ -81,6 +87,15 @@ class ThemeActivity : ComponentActivity() {
     private val tag = "ThemeActivity"
     private lateinit var viewModel: ThemeActivityViewModel
 
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                viewModel.downloadAndInstallTheme(this)
+            } else {
+                Toast.makeText(this, "Storage permission is required to save themes.", Toast.LENGTH_LONG).show()
+            }
+        }
+
     @Inject
     lateinit var httpClient: OkHttpClient
 
@@ -95,53 +110,49 @@ class ThemeActivity : ComponentActivity() {
             return
         }
 
-        var themeName: String? = null
-        var themeDescription: String? = null
-        var themeDownloadUrl: String? = intent.getStringExtra(EXTRA_THEME_URL) // Fallback
+        var finalThemeName: String
+        var finalThemeDescription: String
+        var finalThemeDownloadUrl: String
 
         when (storeType) {
             StoreType.JETBRAINS -> {
-                val themeState = intent.getParcelableExtraApiDependent<JetbrainsThemeCardState>(EXTRA_THEME_STATE)
-                if (themeState == null) {
+                val jetbrainsState = intent.getParcelableExtraApiDependent<JetbrainsThemeCardState>(EXTRA_THEME_STATE)
+                if (jetbrainsState == null) {
                     Log.e(tag, "No JetbrainsThemeCardState passed for JETBRAINS store type.")
                     finish()
                     return
                 }
-                themeName = themeState.name
-                themeDescription = themeState.trimmedDescription
-                // JetbrainsThemeCardState doesn't have a downloadUrl yet.
-                // For now, we'll use previewUrl if EXTRA_THEME_URL is not present.
-                // This will be properly handled in a later step.
-                if (themeDownloadUrl == null) {
-                    themeDownloadUrl = themeState.previewUrl
-                    Log.w(tag, "Using previewUrl as downloadUrl for Jetbrains theme. This should be updated.")
+                finalThemeName = jetbrainsState.name
+                finalThemeDescription = jetbrainsState.trimmedDescription
+                finalThemeDownloadUrl = jetbrainsState.downloadUrl // Now using the direct downloadUrl
+                if (finalThemeDownloadUrl.isEmpty()) {
+                    Log.w(tag, "Jetbrains theme downloadUrl is empty. Check ViewModel logic.")
+                    // Potentially fallback to previewUrl or handle as error, for now proceed
+                     finalThemeDownloadUrl = jetbrainsState.previewUrl // Fallback for safety, though should be populated
                 }
             }
             StoreType.MICROSOFT -> {
-                val themeState = intent.getParcelableExtraApiDependent<MicrosoftStoreCardState>(EXTRA_THEME_STATE)
-                if (themeState == null) {
+                val microsoftState = intent.getParcelableExtraApiDependent<MicrosoftStoreCardState>(EXTRA_THEME_STATE)
+                if (microsoftState == null) {
                     Log.e(tag, "No MicrosoftStoreCardState passed for MICROSOFT store type.")
                     finish()
                     return
                 }
-                themeName = themeState.name
-                themeDescription = themeState.description
-                themeDownloadUrl = themeState.downloadUrl // This is the correct download URL
+                finalThemeName = microsoftState.name
+                finalThemeDescription = microsoftState.description
+                finalThemeDownloadUrl = microsoftState.downloadUrl
             }
         }
 
-        if (themeName == null || themeDescription == null || themeDownloadUrl == null) {
-            Log.e(tag, "Theme details (name, description, or URL) are missing. Cannot display theme.")
+        if (finalThemeDownloadUrl.isEmpty()) {
+            Log.e(tag, "Theme download URL is empty. Cannot proceed.")
             finish()
             return
         }
 
-        // Initialize ViewModel with the determined URL
-        // The ViewModelFactory will use this URL when creating the ViewModel instance
-        viewModel = ViewModelProvider(
-            this,
-            ThemeActivityViewModelFactory(httpClient, themeDownloadUrl)
-        )[ThemeActivityViewModel::class.java]
+        // Initialize ViewModel with the determined URL, Name, and StoreType
+        val factory = ThemeActivityViewModelFactory(httpClient, finalThemeDownloadUrl, finalThemeName, storeType)
+        viewModel = ViewModelProvider(this, factory)[ThemeActivityViewModel::class.java]
 
 
         setContent {
@@ -163,11 +174,32 @@ class ThemeActivity : ComponentActivity() {
                         innerPadding = innerPadding,
                         scrollState = scrollState,
                         viewModel = viewModel,
-                        themeName = themeName,
-                        themeDescription = themeDescription
+                        themeName = finalThemeName,
+                        themeDescription = finalThemeDescription,
+                        onDownloadClick = { this.onDownloadAndPrepareClicked() }
                     )
                 }
             }
+        }
+    }
+
+    fun onDownloadAndPrepareClicked() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    viewModel.downloadAndInstallTheme(this)
+                }
+                // Simplification: Directly request if not granted, skipping rationale for brevity here.
+                // A real app should handle shouldShowRequestPermissionRationale appropriately.
+                else -> {
+                    requestPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                }
+            }
+        } else {
+            viewModel.downloadAndInstallTheme(this)
         }
     }
 }
@@ -178,10 +210,9 @@ private fun ThemeView(
     scrollState: ScrollState,
     viewModel: ThemeActivityViewModel,
     themeName: String,
-    themeDescription: String
+    themeDescription: String,
+    onDownloadClick: () -> Unit
 ) {
-    val context = LocalContext.current
-
     val isDownloading by viewModel.isDownloading.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
     val downloadError by viewModel.downloadError.collectAsState()
@@ -207,7 +238,7 @@ private fun ThemeView(
             )
 
             Button(
-                onClick = { viewModel.downloadAndInstallTheme(context) },
+                onClick = onDownloadClick, // Use the passed lambda
                 enabled = !isDownloading,
                 modifier = Modifier.fillMaxWidth()
             ) {

--- a/app/src/main/java/moe/smoothie/androidide/themestore/data/AndroidIDETheme.kt
+++ b/app/src/main/java/moe/smoothie/androidide/themestore/data/AndroidIDETheme.kt
@@ -1,0 +1,47 @@
+package moe.smoothie.androidide.themestore.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AndroidIDERootTheme(
+    val name: String? = null, // Added: Name for the theme scheme itself
+    val isDark: Boolean = false, // Added: To indicate if it's a dark theme
+    val definitions: Map<String, String>? = null, // e.g., "my_color": "#RRGGBB"
+    val editor: AndroidIDEEditorColors? = null,
+    val languages: List<AndroidIDELanguageStyling>? = null
+)
+
+@Serializable
+data class AndroidIDEEditorColors(
+    val bg: String? = null,
+    val fg: String? = null,
+    @SerialName("gutter.bg")
+    val gutterBg: String? = null,
+    @SerialName("gutter.fg")
+    val gutterFg: String? = null,
+    @SerialName("caret.fg")
+    val caretFg: String? = null,
+    @SerialName("selection.bg")
+    val selectionBg: String? = null,
+    @SerialName("line.highlight.bg") // Example: current line highlight
+    val lineHighlightBg: String? = null,
+    @SerialName("whitespace.fg") // Example: visible whitespace
+    val whitespaceFg: String? = null
+    // Add more common ones as identified
+)
+
+@Serializable
+data class AndroidIDELanguageStyling(
+    val types: List<String>, // e.g., ["java", "xml", "kotlin", "global"] (use "global" for general token types)
+    val styles: Map<String, AndroidIDEStyleEntry> // e.g., "comment": {"fg": "@some_color"}
+)
+
+@Serializable
+data class AndroidIDEStyleEntry(
+    val fg: String? = null,
+    val bg: String? = null,
+    val bold: Boolean? = null,
+    val italic: Boolean? = null,
+    val strikethrough: Boolean? = null
+)

--- a/app/src/main/java/moe/smoothie/androidide/themestore/data/ParsedThemeTypes.kt
+++ b/app/src/main/java/moe/smoothie/androidide/themestore/data/ParsedThemeTypes.kt
@@ -1,0 +1,47 @@
+package moe.smoothie.androidide.themestore.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TokenColorSetting(
+    val name: String? = null,
+    val scope: String? = null, // Note: In VSCode, scope can be String or List<String>. Simplified for now.
+    val settings: Map<String, String>? = null // Settings are typically string key-value pairs for fontStyle, foreground, background
+)
+
+@Serializable
+data class VSCodeThemeJson(
+    val name: String? = null,
+    val type: String? = null, // "light", "dark", "hc"
+    val colors: Map<String, String>? = null, // Editor colors like "editor.background"
+    val tokenColors: List<TokenColorSetting>? = null // Syntax highlighting rules
+)
+
+@Serializable
+data class JetbrainsThemeJson(
+    val name: String? = null,
+    val dark: Boolean? = false,
+    val author: String? = null,
+    val editorScheme: String? = null, // Path to .icls file for editor colors
+    val colors: Map<String, String>? = null, // Specific IDE component colors (e.g. "ActionButton.background")
+    val ui: Map<String, String>? = null, // General UI element colors (e.g. "*": { "background": "#FFFFFF" } )
+    val icons: Map<String, String>? = null // Icon color overrides (e.g. "ColorPalette": {} )
+)
+
+// Not directly from JSON, but for holding structured data from ICLS XML
+data class IclsThemeData(
+    val name: String? = null,
+    val colors: Map<String, String> = emptyMap(), // <colors> entries
+    val attributes: List<IclsAttribute> = emptyList() // <option> entries under <attributes>
+)
+
+data class IclsAttribute(
+    val name: String, // e.g., "TEXT"
+    val value: String? = null, // Raw value string from XML
+    val foreground: String? = null,
+    val background: String? = null,
+    val fontType: String? = null, // "0", "1", "2", "3"
+    val effectColor: String? = null,
+    val effectType: String? = null, // "0", "1", "2", "3", "4", "5"
+    val errorCode: String? = null // For error stripes
+)

--- a/app/src/main/java/moe/smoothie/androidide/themestore/util/ZipUtils.kt
+++ b/app/src/main/java/moe/smoothie/androidide/themestore/util/ZipUtils.kt
@@ -1,0 +1,36 @@
+package moe.smoothie.androidide.themestore.util
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.zip.ZipInputStream
+
+@Throws(IOException::class)
+fun unzip(zipFile: File, targetDirectory: File) {
+    if (!targetDirectory.exists()) {
+        targetDirectory.mkdirs()
+    }
+
+    ZipInputStream(zipFile.inputStream()).use { zis ->
+        var entry = zis.nextEntry
+        while (entry != null) {
+            val newFile = File(targetDirectory, entry.name)
+            // Security check for "Zip Slip" vulnerability
+            if (!newFile.canonicalPath.startsWith(targetDirectory.canonicalPath + File.separator)) {
+                throw IOException("Zip Slip vulnerability detected: Entry is outside of the target dir: ${entry.name}")
+            }
+
+            if (entry.isDirectory) {
+                newFile.mkdirs()
+            } else {
+                // Ensure parent directory exists for files within subdirectories
+                File(newFile.parent!!).mkdirs()
+                FileOutputStream(newFile).use { fos ->
+                    zis.copyTo(fos)
+                }
+            }
+            zis.closeEntry()
+            entry = zis.nextEntry
+        }
+    }
+}

--- a/app/src/main/java/moe/smoothie/androidide/themestore/viewmodels/ThemeActivityViewModel.kt
+++ b/app/src/main/java/moe/smoothie/androidide/themestore/viewmodels/ThemeActivityViewModel.kt
@@ -1,6 +1,7 @@
 package moe.smoothie.androidide.themestore.viewmodels
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
@@ -8,17 +9,34 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import moe.smoothie.androidide.themestore.data.AndroidIDEEditorColors
+import moe.smoothie.androidide.themestore.data.AndroidIDELanguageStyling
+import moe.smoothie.androidide.themestore.data.AndroidIDERootTheme
+import moe.smoothie.androidide.themestore.data.AndroidIDEStyleEntry
+import moe.smoothie.androidide.themestore.data.IclsThemeData
+import moe.smoothie.androidide.themestore.data.JetbrainsThemeJson
+import moe.smoothie.androidide.themestore.data.VSCodeThemeJson
+import moe.smoothie.androidide.themestore.model.StoreType
+import moe.smoothie.androidide.themestore.util.unzip
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.xmlpull.v1.XmlPullParser
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import android.os.Environment // Required for public directory access
 
 
 class ThemeActivityViewModel(
     private val httpClient: OkHttpClient,
-    private val url: String // This is the themeDownloadUrl
+    private val url: String, // This is the themeDownloadUrl
+    private val themeName: String,
+    private val storeType: StoreType
 ) : ViewModel() {
+    private val tag = "ThemeActivityViewModel" // For logging
+    private val jsonParser = Json { ignoreUnknownKeys = true; isLenient = true }
     private val _isLoading = MutableStateFlow(false) // General loading, might be removed if not used
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
@@ -58,20 +76,16 @@ class ThemeActivityViewModel(
                     return@launch
                 }
 
-                val themesDir = File(context.getExternalFilesDir(null), "themes")
-                if (!themesDir.exists()) {
-                    themesDir.mkdirs()
-                }
-
                 // Basic filename extraction, might need improvement
                 val filename = url.substringAfterLast('/', "unknown_theme_file")
-                val themeFile = File(themesDir, filename)
+                // Save to cache directory first
+                val tempDownloadedFile = File(context.cacheDir, filename)
 
                 val totalBytes = body.contentLength()
                 var bytesRead = 0L
 
                 body.byteStream().use { inputStream ->
-                    FileOutputStream(themeFile).use { outputStream ->
+                    FileOutputStream(tempDownloadedFile).use { outputStream ->
                         val buffer = ByteArray(8 * 1024) // 8KB buffer
                         var bytes = inputStream.read(buffer)
                         while (bytes >= 0) {
@@ -84,15 +98,349 @@ class ThemeActivityViewModel(
                         }
                     }
                 }
-                _installStatus.value = "Theme downloaded to ${themeFile.absolutePath}"
+                _installStatus.value = "Downloaded, now processing..."
+                processDownloadedTheme(context, tempDownloadedFile, storeType)
 
             } catch (e: IOException) {
-                _downloadError.value = "Download failed: ${e.message}"
+                _downloadError.value = "File operation failed: ${e.message}"
             } catch (e: Exception) {
                 _downloadError.value = "An unexpected error occurred: ${e.message}"
             } finally {
                 _isDownloading.value = false
             }
+        }
+    }
+
+    private fun processDownloadedTheme(context: Context, downloadedFile: File, storeType: StoreType) {
+        val workingDir = File(context.cacheDir, "theme_processing_${System.currentTimeMillis()}")
+        try {
+            if (!workingDir.mkdirs()) {
+                // It might be that the directory already exists if System.currentTimeMillis() is the same for some reason
+                // or if mkdirs fails for another reason. Add an extra check or alternative.
+                if (!workingDir.exists() || !workingDir.isDirectory) {
+                    throw IOException("Failed to create working directory: ${workingDir.absolutePath}")
+                }
+            }
+
+            val downloadedFilenameLowercase = downloadedFile.name.lowercase()
+            val needsUnzip = when (storeType) {
+                StoreType.JETBRAINS -> downloadedFilenameLowercase.endsWith(".zip") || downloadedFilenameLowercase.endsWith(".jar")
+                StoreType.MICROSOFT -> downloadedFilenameLowercase.endsWith(".vsix")
+            }
+            var themeDefinitionFile: File? = null
+            var parsedThemeData: Any? = null
+
+            if (needsUnzip) {
+                unzip(downloadedFile, workingDir)
+                _installStatus.value = "Unzipped theme package."
+                Log.d(tag, "Unzipped to ${workingDir.absolutePath}")
+
+                if (storeType == StoreType.JETBRAINS) {
+                    themeDefinitionFile = workingDir.walkTopDown().firstOrNull { it.name.endsWith(".theme.json") }
+                    if (themeDefinitionFile == null) {
+                        themeDefinitionFile = workingDir.walkTopDown().firstOrNull { it.name.endsWith(".icls") }
+                    }
+                } else if (storeType == StoreType.MICROSOFT) {
+                    val themesDir = File(workingDir, "extension/themes")
+                    if (themesDir.exists() && themesDir.isDirectory) {
+                        themeDefinitionFile = themesDir.walkTopDown().firstOrNull { it.name.endsWith(".json") }
+                    }
+                }
+            } else {
+                // If not unzipped, check if the downloaded file itself is a theme definition
+                if (downloadedFilenameLowercase.endsWith(".json") || (storeType == StoreType.JETBRAINS && downloadedFilenameLowercase.endsWith(".icls"))) {
+                    val targetFileInWorkingDir = File(workingDir, downloadedFilenameLowercase)
+                    downloadedFile.copyTo(targetFileInWorkingDir, overwrite = true)
+                    themeDefinitionFile = targetFileInWorkingDir
+                    _installStatus.value = "Processing direct theme file."
+                } else {
+                    _installStatus.value = "File is not a recognized archive or direct theme file: $downloadedFilenameLowercase"
+                }
+            }
+
+            if (themeDefinitionFile != null && themeDefinitionFile.exists()) {
+                Log.d(tag, "Theme definition file found: ${themeDefinitionFile.absolutePath}")
+                _installStatus.value = "Found theme file: ${themeDefinitionFile.name}"
+                val fileContent = themeDefinitionFile.readText()
+
+                try {
+                    when {
+                        themeDefinitionFile.extension.equals("json", ignoreCase = true) -> {
+                            parsedThemeData = if (storeType == StoreType.MICROSOFT) {
+                                jsonParser.decodeFromString<VSCodeThemeJson>(fileContent)
+                                    .also { Log.d(tag, "Successfully parsed VSCode theme JSON.") }
+                            } else { // JETBRAINS .theme.json
+                                jsonParser.decodeFromString<JetbrainsThemeJson>(fileContent)
+                                    .also { Log.d(tag, "Successfully parsed Jetbrains theme JSON.") }
+                            }
+                        }
+                        themeDefinitionFile.extension.equals("icls", ignoreCase = true) -> {
+                            Log.d(tag, "ICLS file found: ${themeDefinitionFile.name}. Basic parsing.")
+                            val factory = org.xmlpull.v1.XmlPullParserFactory.newInstance()
+                            val parser = factory.newPullParser()
+                            parser.setInput(themeDefinitionFile.inputStream(), null)
+                            var themeNameFromIcls: String? = null
+                            var eventType = parser.eventType
+                            while (eventType != XmlPullParser.END_DOCUMENT) {
+                                if (eventType == XmlPullParser.START_TAG && parser.name == "scheme") {
+                                    themeNameFromIcls = parser.getAttributeValue(null, "name")
+                                    break
+                                }
+                                eventType = parser.next()
+                            }
+                            parsedThemeData = IclsThemeData(name = themeNameFromIcls)
+                            Log.d(tag, "ICLS theme name extracted: $themeNameFromIcls")
+                            _installStatus.value = "Partially parsed ICLS file (name: $themeNameFromIcls)."
+                        }
+                        else -> {
+                            Log.e(tag, "Unsupported theme definition file type: ${themeDefinitionFile.absolutePath}")
+                            _downloadError.value = "Unsupported theme file type: ${themeDefinitionFile.extension}"
+                            deleteWorkingDir(workingDir)
+                            return // from processDownloadedTheme
+                        }
+                    }
+                } catch (e: Exception) { // Catches SerializationException and XmlPullParserException etc.
+                    Log.e(tag, "Failed to parse theme file ${themeDefinitionFile.name}: ${e.message}", e)
+                    _downloadError.value = "Failed to parse theme file: ${e.message}"
+                    deleteWorkingDir(workingDir)
+                    return // from processDownloadedTheme
+                }
+
+                if (parsedThemeData != null) {
+                    Log.d(tag, "Theme data parsed successfully.")
+                    _installStatus.value = "Theme file parsed: ${themeDefinitionFile.name}"
+
+                    var isDarkInferred = false
+                    if (parsedThemeData is JetbrainsThemeJson) {
+                        isDarkInferred = parsedThemeData.dark ?: false
+                    } else if (parsedThemeData is VSCodeThemeJson) {
+                        if (themeDefinitionFile.name.contains("dark", ignoreCase = true) ||
+                            (parsedThemeData.name ?: "").contains("dark", ignoreCase = true) ||
+                            parsedThemeData.type?.contains("dark", ignoreCase = true) == true) {
+                            isDarkInferred = true
+                        }
+                    } else if (parsedThemeData is IclsThemeData) {
+                        if ((parsedThemeData.name ?: "").contains("dark", ignoreCase = true)) {
+                            isDarkInferred = true
+                        }
+                        // Additionally, ICLS might imply dark through background color, but that's more complex.
+                    }
+
+                    val androidIdeTheme = transformToAndroidIDETheme(parsedThemeData, themeName, isDarkInferred, themeDefinitionFile.name)
+                    if (androidIdeTheme != null) {
+                        try {
+                            val finalJsonString = jsonParser.encodeToString(androidIdeTheme)
+                            // Determine schemeId
+                            var tempSchemeId = themeName.replace(Regex("[^a-zA-Z0-9_.-]"), "_").lowercase()
+                            if (tempSchemeId.isBlank()) {
+                                tempSchemeId = "custom_theme_" + System.currentTimeMillis()
+                            }
+                            val schemeId = tempSchemeId
+                            val schemeFileName = "$schemeId.json"
+
+                            // Construct scheme.prop content
+                            val propBuilder = StringBuilder()
+                            propBuilder.append("scheme.name=").append(themeName).append("\n") // Use original themeName for display
+                            propBuilder.append("scheme.version=1").append("\n")
+                            propBuilder.append("scheme.isDark=").append(isDarkInferred).append("\n")
+                            propBuilder.append("scheme.file=").append(schemeFileName)
+                            val schemePropContent = propBuilder.toString()
+
+                            // Prepare Output Directory
+                            val publicDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                            val themesBaseDir = File(publicDir, "AndroidIDEThemes")
+                            if (!themesBaseDir.exists()) { themesBaseDir.mkdirs() }
+                            val finalThemeDir = File(themesBaseDir, schemeId)
+                            if (finalThemeDir.exists()) { finalThemeDir.deleteRecursively() }
+                            finalThemeDir.mkdirs()
+
+                            // Write Files
+                            try {
+                                File(finalThemeDir, schemeFileName).writeText(finalJsonString)
+                                File(finalThemeDir, "scheme.prop").writeText(schemePropContent)
+                                Log.d(tag, "AndroidIDE theme '$schemeId' saved to ${finalThemeDir.absolutePath}")
+                                _installStatus.value = "Theme '$themeName' prepared for AndroidIDE.\nSaved to: Downloads/AndroidIDEThemes/$schemeId\n\nInstructions:\n1. Open AndroidIDE.\n2. Navigate to Editor settings > Color Scheme.\n3. Use AndroidIDE's import function to install it by selecting the '$schemeId' folder or its files from the path above, OR manually copy the '$schemeId' folder to AndroidIDE's internal schemes directory if you have advanced access."
+                                // Successfully packaged, now delete workingDir
+                                deleteWorkingDir(workingDir)
+                            } catch (ioe: IOException) {
+                                Log.e(tag, "Failed to write theme files: ${ioe.message}", ioe)
+                                _downloadError.value = "Failed to save prepared theme: ${ioe.message}"
+                                deleteWorkingDir(workingDir) // Also clean up workingDir on write error
+                            }
+
+                        } catch (e: Exception) { // Catch error from jsonParser.encodeToString
+                            Log.e(tag, "Error serializing transformed theme: ${e.message}", e)
+                            _downloadError.value = "Failed to serialize final theme: ${e.message}"
+                            deleteWorkingDir(workingDir)
+                        }
+                    } else { // transformToAndroidIDETheme returned null
+                        _downloadError.value = "Failed to transform theme for AndroidIDE."
+                        deleteWorkingDir(workingDir)
+                    }
+
+                } else if (_downloadError.value == null) { // parsedThemeData was null, and no earlier error set
+                    _downloadError.value = "Failed to obtain parsed data, though file was found."
+                    deleteWorkingDir(workingDir)
+                }
+
+            } else { // themeDefinitionFile was null or did not exist
+                Log.e(tag, "Could not find theme definition file in ${workingDir.absolutePath} or from direct file.")
+                _downloadError.value = "Could not find theme definition file."
+                deleteWorkingDir(workingDir) // Clean up if definition file not found
+            }
+
+        } catch (e: IOException) { // Catch errors from initial file operations or unzipping
+            _downloadError.value = "Error processing theme: ${e.message}"
+            deleteWorkingDir(workingDir)
+        } catch (e: Exception) { // Catch any other unexpected errors
+            _downloadError.value = "Unexpected error during theme processing: ${e.message}"
+            deleteWorkingDir(workingDir)
+        } finally {
+            // Clean up the original temporary downloaded file (archive or raw)
+            if (downloadedFile.exists()) {
+                downloadedFile.delete()
+            }
+            // Ensure workingDir is cleaned IF an error occurred and it wasn't cleaned by specific error handling
+            // This is a fallback; ideally, specific error handlers should manage workingDir cleanup.
+            // However, if an error occurs BEFORE workingDir is used for successful packaging, it should be cleaned.
+            // If _downloadError is set and workingDir exists, it implies an issue before successful packaging.
+            if (_downloadError.value != null && workingDir.exists()) {
+                 // deleteWorkingDir(workingDir) // Re-evaluating: workingDir is now cleaned in most error paths.
+                 // If an error occurs, workingDir *should* be cleaned by the catch block that sets the error.
+                 // This final check might be redundant or could hide logic errors if specific handlers miss cleanup.
+                 // For now, let's assume specific handlers do their job.
+            }
+        }
+    }
+
+    private fun transformToAndroidIDETheme(
+        parsedData: Any?,
+        originalThemeName: String, // The name from the store/card state
+        isDarkTheme: Boolean,
+        themeDefinitionFilename: String // Filename of the parsed definition file
+    ): AndroidIDERootTheme? {
+        val definitionsMap = mutableMapOf<String, String>()
+        val editorColorsValues = mutableMapOf<String, String>() // Store direct color values for editor
+        var languageStyling: AndroidIDELanguageStyling? = null
+
+        // Helper to add to definitions and return reference
+        fun defineColor(name: String, colorValue: String?): String? {
+            if (colorValue.isNullOrBlank() || !colorValue.startsWith("#")) return null // Basic validation
+            val defName = name.replace(".", "_").lowercase() // Sanitize for definition key
+            definitionsMap[defName] = colorValue
+            return "@$defName"
+        }
+
+        when (parsedData) {
+            is VSCodeThemeJson -> {
+                parsedData.colors?.forEach { (key, value) ->
+                    when (key) {
+                        "editor.background" -> editorColorsValues["bg"] = defineColor("editor_bg", value) ?: value
+                        "editor.foreground" -> editorColorsValues["fg"] = defineColor("editor_fg", value) ?: value
+                        "editorCursor.foreground" -> editorColorsValues["caretFg"] = defineColor("editor_caret_fg", value) ?: value
+                        "editor.selectionBackground" -> editorColorsValues["selectionBg"] = defineColor("editor_selection_bg", value) ?: value
+                        "editorGutter.background" -> editorColorsValues["gutterBg"] = defineColor("editor_gutter_bg", value) ?: value
+                        "editorLineNumber.foreground" -> editorColorsValues["gutterFg"] = defineColor("editor_gutter_fg", value) ?: value
+                        "editor.lineHighlightBackground" -> editorColorsValues["lineHighlightBg"] = defineColor("editor_line_highlight_bg", value) ?: value
+                        "editorWhitespace.foreground" -> editorColorsValues["whitespaceFg"] = defineColor("editor_whitespace_fg", value) ?: value
+                        // Add more direct mappings here
+                    }
+                }
+                // Simplified token color mapping (comment example)
+                val commentToken = parsedData.tokenColors?.find { it.scope?.contains("comment") == true }
+                commentToken?.settings?.get("foreground")?.let { fg ->
+                    val commentFgRef = defineColor("comment_fg", fg)
+                    if (commentFgRef != null) {
+                        languageStyling = AndroidIDELanguageStyling(
+                            types = listOf("global"), // Apply to all, or detect language
+                            styles = mapOf("comment" to AndroidIDEStyleEntry(fg = commentFgRef))
+                        )
+                    }
+                }
+            }
+            is JetbrainsThemeJson -> {
+                val jbColors = parsedData.colors ?: emptyMap()
+                val jbUi = parsedData.ui ?: emptyMap()
+
+                // Prioritize specific keys, then general UI keys, then fallback from `colors` map
+                val bg = jbUi["Editor.background"] ?: jbColors["BACKGROUND"]
+                val fg = jbUi["Editor.foreground"] ?: jbColors["FOREGROUND"]
+                val caret = jbUi["Caret.foreground"] ?: jbColors["CARET"]
+                val selection = jbUi["Editor.selectionBackground"] ?: jbColors["SELECTION_BACKGROUND"]
+                val gutterBg = jbUi["Gutter.background"] ?: jbColors["GUTTER_BACKGROUND"] // Jetbrains often uses "Gutter.background"
+                val gutterFg = jbUi["EditorLineNumber.foreground"] ?: jbColors["LINE_NUMBERS_COLOR"]
+                val lineHighlight = jbUi["Editor.caretRowBackground"] ?: jbColors["CARET_ROW_COLOR"]
+
+                editorColorsValues["bg"] = defineColor("editor_bg", bg) ?: bg
+                editorColorsValues["fg"] = defineColor("editor_fg", fg) ?: fg
+                editorColorsValues["caretFg"] = defineColor("editor_caret_fg", caret) ?: caret
+                editorColorsValues["selectionBg"] = defineColor("editor_selection_bg", selection) ?: selection
+                editorColorsValues["gutterBg"] = defineColor("editor_gutter_bg", gutterBg) ?: gutterBg
+                editorColorsValues["gutterFg"] = defineColor("editor_gutter_fg", gutterFg) ?: gutterFg
+                editorColorsValues["lineHighlightBg"] = defineColor("editor_line_highlight_bg", lineHighlight) ?: lineHighlight
+
+                // Simplified comment mapping for JetBrains
+                jbColors["COMMENT_FOREGROUND"]?.let { fgColor ->
+                     val commentFgRef = defineColor("comment_fg", fgColor)
+                     if (commentFgRef != null) {
+                        languageStyling = AndroidIDELanguageStyling(
+                            types = listOf("global"),
+                            styles = mapOf("comment" to AndroidIDEStyleEntry(fg = commentFgRef))
+                        )
+                    }
+                }
+            }
+            is IclsThemeData -> {
+                // ICLS parsing is very basic, only name was extracted.
+                // A more complete ICLS parser would populate parsedData.colors and parsedData.attributes.
+                // For now, we'll rely on the name for darkness and potentially defaults.
+                // Example: if parsedData.colors had "BACKGROUND"
+                // editorColorsValues["bg"] = defineColor("editor_bg", parsedData.colors["BACKGROUND"]) ?: parsedData.colors["BACKGROUND"]
+                Log.d(tag, "ICLS transformation is minimal, using theme name: ${parsedData.name}")
+            }
+            else -> {
+                Log.e(tag, "Unsupported parsed data type: ${parsedData?.javaClass?.name}")
+                return null
+            }
+        }
+
+        if (editorColorsValues.isEmpty() && languageStyling == null && definitionsMap.isEmpty()) {
+            Log.w(tag, "No relevant theme data extracted for AndroidIDE format from $themeDefinitionFilename.")
+            return null
+        }
+
+        val finalEditorColors = AndroidIDEEditorColors(
+            bg = editorColorsValues["bg"],
+            fg = editorColorsValues["fg"],
+            gutterBg = editorColorsValues["gutterBg"],
+            gutterFg = editorColorsValues["gutterFg"],
+            caretFg = editorColorsValues["caretFg"],
+            selectionBg = editorColorsValues["selectionBg"],
+            lineHighlightBg = editorColorsValues["lineHighlightBg"],
+            whitespaceFg = editorColorsValues["whitespaceFg"]
+        )
+
+        return AndroidIDERootTheme(
+            name = originalThemeName, // Use the name from the store/manifest
+            isDark = isDarkTheme,
+            definitions = definitionsMap.ifEmpty { null },
+            editor = if (finalEditorColors.reflectivelyHasAnyNonNull()) finalEditorColors else null,
+            languages = languageStyling?.let { listOf(it) }
+        )
+    }
+
+    // Helper extension to check if any property of a data class is non-null
+    private fun Any.reflectivelyHasAnyNonNull(): Boolean {
+        return this::class.java.declaredFields.any { field ->
+            field.isAccessible = true
+            field.get(this) != null
+        }
+    }
+
+    private fun deleteWorkingDir(workingDir: File) {
+        if (workingDir.exists()) {
+            workingDir.deleteRecursively()
+            Log.d(tag, "Cleaned up working directory: ${workingDir.path}")
         }
     }
 }

--- a/app/src/main/java/moe/smoothie/androidide/themestore/viewmodels/ThemeActivityViewModelFactory.kt
+++ b/app/src/main/java/moe/smoothie/androidide/themestore/viewmodels/ThemeActivityViewModelFactory.kt
@@ -2,6 +2,7 @@ package moe.smoothie.androidide.themestore.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import moe.smoothie.androidide.themestore.model.StoreType
 import okhttp3.OkHttpClient
 
 /**
@@ -12,11 +13,13 @@ import okhttp3.OkHttpClient
 @Suppress("UNCHECKED_CAST")
 class ThemeActivityViewModelFactory(
     private val httpClient: OkHttpClient,
-    private val themeDownloadUrl: String
+    private val themeDownloadUrl: String,
+    private val themeName: String,
+    private val storeType: StoreType
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(ThemeActivityViewModel::class.java)) {
-            return ThemeActivityViewModel(httpClient, themeDownloadUrl) as T
+            return ThemeActivityViewModel(httpClient, themeDownloadUrl, themeName, storeType) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
     }


### PR DESCRIPTION
Here's a rundown of what I've done:

This feature enables the download of themes from JetBrains and VSCode
marketplaces, processes them, transforms them into AndroidIDE's
compatible JSON format, and packages them for your manual installation.

Key changes and features:

1.  **Theme Downloading**:
    *   I'll download the raw theme files (.jar for JetBrains, .vsix for VSCode)
      to a temporary cache directory.

2.  **Theme File Processing**:
    *   I'll manage `storeType` (JetBrains/Microsoft) and `themeName` in the
      `ThemeActivityViewModel`.
    *   I've included a `ZipUtils.unzip` utility for extracting theme archives.
    *   I'll identify the main theme definition files (`.theme.json`, `.icls` for
      JetBrains; `extension/themes/*.json` for VSCode) within the
      unzipped content.

3.  **Theme Parsing**:
    *   I've defined Kotlin data classes (`ParsedThemeTypes.kt`) for VSCode
      JSON themes, JetBrains `.theme.json` themes, and a basic structure
      for JetBrains `.icls` files.
    *   I'll use `kotlinx.serialization.json` for parsing JSON theme files.
    *   I've implemented basic XML parsing using `XmlPullParser` to extract the
      name from `.icls` files.

4.  **Theme Transformation**:
    *   I've defined Kotlin data classes (`AndroidIDETheme.kt`) for AndroidIDE's
      specific theme JSON structure (root, editor colors, language styling).
    *   I've implemented a `transformToAndroidIDETheme` function in
      `ThemeActivityViewModel` to map parsed data from source themes
      (VSCode, JetBrains JSON) to the AndroidIDE format. This includes:
        *   Mapping common editor colors (background, foreground, caret,
          selection, gutter, etc.).
        *   Creating a `definitions` map for color variables (e.g., "@editor_bg").
        *   Basic mapping for comment token colors.
        *   Inferring the `isDark` property for the theme.

5.  **Packaging for AndroidIDE**:
    *   I'll generate a unique `schemeId` from the theme name.
    *   I'll create a `scheme.prop` file with `scheme.name`, `scheme.version`,
      `scheme.isDark`, and `scheme.file` (pointing to the transformed JSON).
    *   I'll save the transformed theme JSON (e.g., `<schemeId>.json`) and
      `scheme.prop` into a dedicated folder:
      `Downloads/AndroidIDEThemes/<scheme_id>/`.
    *   I'll clean up temporary working directories after processing.

6.  **Permissions**:
    *   I've added `<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />`
      and `READ_EXTERNAL_STORAGE` for compatibility with older Android
      versions when saving to the public `Downloads` directory.
    *   I've implemented runtime permission requests in `ThemeActivity` for
      `WRITE_EXTERNAL_STORAGE` on Android versions below Q (API 29).

7.  **UI and User Guidance**:
    *   The button text in `ThemeActivity` is now "Download and Prepare Theme".
    *   I'll provide you with detailed status messages and instructions
      via `_installStatus` LiveData, guiding you on where the prepared
      theme is saved and how to manually copy/import it into AndroidIDE.

The implementation follows the "Option C" approach for installation,
where the app prepares the theme files, and you manually transfer
them to AndroidIDE, using AndroidIDE's import functionality or by
direct copy if you're an advanced user.